### PR TITLE
add typescript definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,8 @@ setPrototypeOf(obj, {
 });
 obj.foo(); // bar
 ```
+
+TypeScript is also supported:
+```typescript
+import setPrototypeOf = require('setprototypeof');
+```

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,2 @@
+declare function setPrototypeOf(o: any, proto: object | null): any;
+export = setPrototypeOf;

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.3",
   "description": "A small polyfill for Object.setprototypeof",
   "main": "index.js",
+  "typings": "index.d.ts",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
Hi!

This PR adds TypeScript typings. `setPrototypeOf` definition is taken from https://github.com/Microsoft/TypeScript/blob/master/src/lib/es2015.core.d.ts#L321