### PR TITLE
Change typescript import example

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,5 +27,5 @@ obj.foo() // bar
 TypeScript is also supported:
 
 ```typescript
-import setPrototypeOf = require('setprototypeof')
+import setPrototypeOf from 'setprototypeof'
 ```


### PR DESCRIPTION
I was confused by this example after second glance.  I reached out to some TS savy co-workers and they agree this is a better example usage.  I will leave this here for comment for a bit before merging.

And here is a reference they linked for the history of the old syntax: https://blog.jdriven.com/2017/06/typescript-and-es6-import-syntax/