### PR TITLE
Fix inheritance in IE9 and IE10

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,8 +13,8 @@ function inheritProperties (obj, proto) {
     var prop = props[i]
     if (!obj.hasOwnProperty(prop)) {
       Object.defineProperty(obj, prop, {
-        get: function() { return proto[prop] },
-        set: function(val) { delete obj[prop]; obj[prop] = val },
+        get: (function(prop) {return function() { return proto[prop] }})(prop),
+        set: (function(prop) {return function(val) { delete obj[prop]; obj[prop] = val }})(prop),
         enumerable: proto.propertyIsEnumerable(prop),
         configurable: true
       })

--- a/index.js
+++ b/index.js
@@ -8,7 +8,9 @@ function setProtoOf (obj, proto) {
 }
 
 function inheritProperties (obj, proto) {
-  for (var prop in proto) {
+  var props = Object.getOwnPropertyNames(proto)
+  for (var i=0; i<props.length; i++) {
+    var prop = props[i]
     if (!obj.hasOwnProperty(prop)) {
       Object.defineProperty(obj, prop, {
         get: function() { return proto[prop] },

--- a/index.js
+++ b/index.js
@@ -13,6 +13,7 @@ function inheritProperties (obj, proto) {
       Object.defineProperty(obj, prop, {
         get: function() { return proto[prop] },
         set: function(val) { delete obj[prop]; obj[prop] = val },
+        enumerable: proto.propertyIsEnumerable(prop),
         configurable: true
       })
     }

--- a/index.js
+++ b/index.js
@@ -1,9 +1,22 @@
 'use strict'
 /* eslint no-proto: 0 */
-module.exports = Object.setPrototypeOf || ({ __proto__: [] } instanceof Array ? setProtoOf : mixinProperties)
+module.exports = Object.setPrototypeOf || ({ __proto__: [] } instanceof Array ? setProtoOf : (Object.defineProperty && definePropertySupport()) ? inheritProperties : mixinProperties)
 
 function setProtoOf (obj, proto) {
   obj.__proto__ = proto
+  return obj
+}
+
+function inheritProperties (obj, proto) {
+  for (var prop in proto) {
+    if (!obj.hasOwnProperty(prop)) {
+      Object.defineProperty(obj, prop, {
+        get: function() { return proto[prop] },
+        set: function(val) { delete obj[prop]; obj[prop] = val },
+        configurable: true
+      })
+    }
+  }
   return obj
 }
 
@@ -14,4 +27,13 @@ function mixinProperties (obj, proto) {
     }
   }
   return obj
+}
+
+function definePropertySupport() {
+  try {
+    Object.defineProperty({}, 'x', {});
+    return true;
+  } catch (e) {
+    return false;
+  }
 }


### PR DESCRIPTION
Following up on #9, this PR fixes object inheritance in IE9/10 by:

- detecting if Object.defineProperty is fully supported (IE9+)
- using "getter" properties to link to the original prototype
- deleting the getter if the property is overridden on the new object
- if Object.defineProperty is not fully supported (IE8 etc), it defaults to the older mixinProperties method

From my testing, IE9/10 now behave identically to modern browsers, with one exception: if a property is overridden (deleting the getter) then deleted again, a modern browser would return to the prototype, whereas here the property would be gone. This is still an improvement over the existing system.

---

**Copied over from #9 to consolidate:**

Hi @wesleytodd, thanks for the package! It looks simple and very well-used.

By my testing, this does not behave correctly on IE9/10 - is that correct? What I mean is the problem described [here](https://babeljs.io/docs/en/babel-plugin-transform-proto-to-assign#detail), where changes to the parent prototype aren't reflected in the child:

```js
var foo = { a: 1 };
var bar = { b: 2 };
setPrototypeOf(bar, foo);
bar.a; // 1
foo.a = 2;
bar.a; // 1 - should be 2
```

IE9/10 do not have [setPrototypeOf](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/setPrototypeOf) or [\_\_proto\_\_](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/proto), which means that they will default to the `mixinProperties` definition. Looks like that just copies the properties with no link. My testing confirms that `bar.a` returns 1 instead of 2 at the end, using `setPrototypeOf()` in IE9/10.

Is this deliberate? I believe I could fix the behaviour, let me know and I'll submit a PR.

**Edit:** Changed the example to use the `setPrototypeOf()` syntax.