### PR TITLE
correct definition file

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,2 +1,2 @@
-declare function setPrototypeOf(o: any, proto: object | null): any;
+declare function setPrototypeOf(o: object, proto: object | null): object;
 export = setPrototypeOf;


### PR DESCRIPTION
Hi @wesleytodd  this corrects the definition file for typescript for setprotypeof so that the parameter o only accepts an object and only returns an object. This is because primitive types do not support adding functions to them.
![setprototypeof](https://user-images.githubusercontent.com/5825929/62992977-984fa500-be23-11e9-9f4a-29efac628946.PNG)
Setting the it equals to object excludes primitive data types https://www.typescriptlang.org/docs/handbook/basic-types.html#object
